### PR TITLE
recursively load nested $refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ Gemfile.lock
 doc/
 tmp/
 *.swp
+.idea
+.ruby-gemset
+.ruby-version
+*.swp
+*.swo
+tags

--- a/lib/schema_tools/modules/hash.rb
+++ b/lib/schema_tools/modules/hash.rb
@@ -123,11 +123,11 @@ module SchemaTools
         res = []
         if obj.respond_to?( field ) && rel_objects = obj.send( field )
           rel_objects.each do |rel_obj|
-            res << if prop['properties'] && prop['properties']['$ref']
+            res << if prop['properties'] #&& prop['properties']['$ref']
                       #got schema describing the objects
                       from_schema(rel_obj, opts)
-                    else
-                      rel_obj
+                    #else
+                    #  rel_obj
                     end
           end
         end
@@ -143,20 +143,20 @@ module SchemaTools
       def parse_object(obj, field, prop, opts)
         res = nil
         if obj.respond_to?( field ) && rel_obj = obj.send( field )
-          if prop['properties'] && prop['properties']['$ref']
+          if prop['properties'] # && prop['properties']['$ref']
             res = from_schema(rel_obj, opts)
           elsif prop['oneOf']
             # auto-detects which schema to use depending on the rel_object type
             # Simpler than detecting the object type or $ref to use inside the
             # oneOf array
             res = from_schema(rel_obj, opts)
-          else
-            # NO recursion directly get values from related object. Does
-            # NOT allow deeper nesting so you MUST define an own schema to be save
-            res = { }
-            prop['properties'].each do |fld, prp|
-              res[fld] = rel_obj.send(fld) if rel_obj.respond_to?(fld)
-            end
+#          else
+#            # NO recursion directly get values from related object. Does
+#            # NOT allow deeper nesting so you MUST define an own schema to be save
+#            res = { }
+#            prop['properties'].each do |fld, prp|
+#              res[fld] = rel_obj.send(fld) if rel_obj.respond_to?(fld)
+#            end
           end
         end
         res

--- a/spec/fixtures/basic_definitions.json
+++ b/spec/fixtures/basic_definitions.json
@@ -8,6 +8,13 @@
         "some_other_property": {
             "description": "whatever",
             "type": "string"
+        },
+        "nested_object" : {
+          "type": "object",
+          "properties" : {
+            "prop1" : { "type" : "string"},
+            "prop2" : { "type" : "string"}
+          }
         }
     }
 }

--- a/spec/fixtures/includes_deep_nested_refs.json
+++ b/spec/fixtures/includes_deep_nested_refs.json
@@ -1,0 +1,21 @@
+{
+  "type" : "object",
+  "description" : "deeply nested",
+  "properties" : {
+    "contains_nesting" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "own_property" : { "type" : "string" },
+          "nested_ref"   : {
+            "type" : "object",
+            "properties" : {
+              "$ref" : "./basic_definitions.json#definitions/nested_object/properties"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/fixtures/page.json
+++ b/spec/fixtures/page.json
@@ -59,7 +59,7 @@
     "blocks": {
       "description": "Placeholder blocks on this page,, if it belongs to a PDF Template",
       "type": "array",
-      "properties": {"$ref":"./block.json#properties"}
+      "properties": {"$ref":"./basic_definitions.json#definitions/nested_object/properties"}
     }
 
   },

--- a/spec/schema_tools/reader_spec.rb
+++ b/spec/schema_tools/reader_spec.rb
@@ -56,6 +56,12 @@ describe SchemaTools::Reader do
       schema[:properties][:id]["$ref"].should be_nil
     end
 
+    it 'deals with nested referenced parameters properly' do
+      schema = SchemaTools::Reader.read(:includes_deep_nested_refs)
+    puts schema
+      schema[:properties].should_not be_empty
+    end
+
     it 'enforces correct parameter usage' do
       expect { SchemaTools::Reader.read(:contact, []) }.to raise_error ArgumentError
     end

--- a/spec/schema_tools/ref_resolver_spec.rb
+++ b/spec/schema_tools/ref_resolver_spec.rb
@@ -66,6 +66,6 @@ describe SchemaTools::RefResolver do
   it 'should load local ref' do
     pointer = "./basic_definitions.json#definitions"
     obj = SchemaTools::RefResolver.load_json_pointer(pointer)
-    obj.length.should eq 2
+    obj.length.should eq 3
   end
 end


### PR DESCRIPTION
Hi Schorsch,

ich habe die Schema Tools mal so angepasst, dass sie rekursiv das gesammte Schema nach $refs abklappern und die beim Laden aufloesen.

Das kommt aber ein bisschen mit Deinem bisherigen vorgehen in die Quere, $refs als Indikatoren fuer genestete Typen zu nutzen, bzw. Array Inhalte mit Properties zu definieren. Zwei tests schlagen fehl und ich bin mir nicht sicher, wie Du das handeln willst (zumindest ohne dass die Schema Tools fuer Saleskind schemas nicht mehr funktionieren.)  Die Fehler treten bei diesem Konstrukt auf:

```
"links_clicked":{
  "description": "Timestamps of clicks. Test nested array values without object reference",
  "type":"array",
  "properties":{
    "type": "string"
  }
},
```

Im Prinzip muesste es ja auch lauten:

```
properties : {
    property_name : {type: string}
}
```

Aber ich schaetze, dass Du das auch in Deinen echten Schemas so machst. Also: great big fuckup. Einmal Schema Tools neuschreiben, bitte!

Wie gesagt, schau Dir mal die failenden Tests an...
