### PR TITLE
No null values for objects

### DIFF
--- a/lib/schema_tools/modules/hash.rb
+++ b/lib/schema_tools/modules/hash.rb
@@ -176,9 +176,9 @@ module SchemaTools
       # @param [Hash] opts to_schema options
       # @return [Array<Hash{String=>String}>]
       def parse_object(obj, field, prop, opts)
-        return if !obj.respond_to?( field )
+        return {} if !obj.respond_to?( field )
         rel_obj = obj.send( field )
-        return if !rel_obj
+        return {} if !rel_obj
 
         res = if prop['properties']
                 opts[:schema] = prop

--- a/lib/schema_tools/modules/hash.rb
+++ b/lib/schema_tools/modules/hash.rb
@@ -180,9 +180,11 @@ module SchemaTools
         rel_obj = obj.send( field )
         return {} if !rel_obj
 
-        res = if prop['properties']
+        res = if prop['properties'].present?
                 opts[:schema] = prop
                 from_schema(rel_obj, opts)
+              elsif prop['properties'].blank?
+                obj.send(field)
               elsif prop['oneOf']
                 # auto-detects which schema to use depending on the rel_object type
                 # Simpler than detecting the object type or $ref to use inside the

--- a/spec/schema_tools/hash_spec.rb
+++ b/spec/schema_tools/hash_spec.rb
@@ -113,9 +113,9 @@ describe SchemaTools::Hash do
       hash['addresses'].should == []
     end
 
-    it 'has nil if nested object is missing' do
+    it 'does not have the key if nested object is missing' do
       hash = SchemaTools::Hash.from_schema(client)
-      hash['work_address'].should be_nil
+      hash.has_key?('work_address').should == false
     end
 
     it 'has nested array values' do
@@ -170,9 +170,9 @@ describe SchemaTools::Hash do
       hash['addresses'].should == []
     end
 
-    it 'has nil if nested object is missing' do
+    it 'does not have the key if nested object is missing' do
       hash = SchemaTools::Hash.from_schema(client)
-      hash['work_address'].should be_nil
+      hash.has_key?('work_address').should == false
     end
 
     it 'has nested array values' do


### PR DESCRIPTION
Previously, objects were being added nil values. This is not ideal because lots of APIs have validations around nil objects, therefore, this PR makes it so that the objects aren't even added in the first place. 