### PR TITLE
Support arbitrary field object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ##2015-03
 
-* allow $refs to include plain schema file name
-* add $schema version to each file
+* allow $refs to include plain schema file name without #suffix
 
 ##2015-01
 

--- a/lib/schema_tools/modules/hash.rb
+++ b/lib/schema_tools/modules/hash.rb
@@ -180,7 +180,7 @@ module SchemaTools
         rel_obj = obj.send( field )
         return if !rel_obj
 
-        res = if prop['properties']
+        res = if prop['properties'].present?
                 opts[:schema] = prop
                 from_schema(rel_obj, opts)
               elsif prop['oneOf']
@@ -188,6 +188,8 @@ module SchemaTools
                 # Simpler than detecting the object type or $ref to use inside the
                 # oneOf array
                 from_schema(rel_obj, opts)
+              elsif prop['properties'].blank?
+                rel_obj
               end
         res
       end

--- a/spec/fixtures/schemata/nested_object_no_properties.json
+++ b/spec/fixtures/schemata/nested_object_no_properties.json
@@ -1,0 +1,7 @@
+{
+  "type" : "object",
+  "id" : { "type" : "string" },
+  "properties" : {
+    "user_data" : { "type" : "object" }
+  }
+}

--- a/spec/fixtures/schemata/nested_object_no_properties.json
+++ b/spec/fixtures/schemata/nested_object_no_properties.json
@@ -1,7 +1,7 @@
 {
   "type" : "object",
-  "id" : { "type" : "string" },
   "properties" : {
+    "id" : { "type" : "string" },
     "user_data" : { "type" : "object" }
   }
 }

--- a/spec/schema_tools/hash_spec.rb
+++ b/spec/schema_tools/hash_spec.rb
@@ -33,6 +33,10 @@ class AnotherAddress
   has_schema_attrs 'address'
 end
 
+class NestedObjectNoProperties
+ include SchemaTools::Modules::Attributes
+ has_schema_attrs 'nested_object_no_properties'
+end
 
 describe SchemaTools::Hash do
 
@@ -266,7 +270,16 @@ describe SchemaTools::Hash do
       hash = SchemaTools::Hash.from_schema(client, base_url: 'http://json-hell.com', links: true)
       hash['_links'].last['href'].should == 'http://json-hell.com/clients/123/Peter'
     end
+  end
 
+  context 'with a nested object that does not have properties' do
+    let(:input_hash) { { foo: 'bar', baz: 'boom' } }
+    let(:nested_object_no_properties) { NestedObjectNoProperties.from_hash(user_data: input_hash) }
+
+    it 'should output the input hash' do
+      hash = SchemaTools::Hash.from_schema(nested_object_no_properties)
+      hash['user_data'].should == input_hash
+    end
   end
 end
 


### PR DESCRIPTION
If we have a nested object with the following schema:
```json
...
"user_data" : { "type" : "object" }
...
```
then that object should be able to hold any values, because it is just a blob of data (an object). Currently, calling `as_schema_hash` will simply set `user_data` to nil. 