### PR TITLE
Support nested objects and collections on initialization

### DIFF
--- a/lib/schema_tools/modules/attributes.rb
+++ b/lib/schema_tools/modules/attributes.rb
@@ -149,22 +149,11 @@ module SchemaTools
         end
 
         def nested_class(field_name)
-          klass = "#{base_class}::#{field_name.to_s.camelize}"
-          if is_a_defined_class?(klass)
-            klass.constantize
-          end
+          "#{base_class}::#{field_name.to_s.camelize}".safe_constantize
         end
 
         def base_class
           self.to_s.deconstantize
-        end
-
-        # This is a little ugly, because we cannot use Object.const_get. That is because
-        # const_get works only if the class has already been autoloaded. Find a way to refactor
-        def is_a_defined_class?(klass)
-          true if Kernel.const_get(klass)
-        rescue NameError
-          false
         end
       end
     end

--- a/lib/schema_tools/modules/attributes.rb
+++ b/lib/schema_tools/modules/attributes.rb
@@ -85,34 +85,26 @@ module SchemaTools
           obj ||= new
           hash.each do |key, val|
             next unless obj.respond_to?(key)
+            conv_val = nil
             # set values to raw schema attributes, even if there are no setters
             # assuming this objects comes from a remote site
             field_props = self.schema['properties']["#{key}"]
             field_type = field_props['type']
-            conv_val = if val.nil?
-                         val
-                       elsif field_type == 'string'
-                         if field_props['format'] == 'date'
-                          Date.parse(val) # or be explicit? Date.strptime('2001-02-03', '%Y-%m-%d')
-                         elsif field_props['format'] == 'date-time'
-                           Time.parse(val) # vs Time.strptime
-                         else
-                          "#{val}"
-                         end
-                       elsif field_type == 'integer'
-                         val.to_i
-                       elsif field_type == 'object'
-                         if nested_class(key)
-                           nested_class(key).from_hash(val)
-                         else
-                           val
-                         end
-                       # elsif field_props['type'] == 'array'
-                        #something
-                       else # rely on preceding call e.g from_json for boolean, number
-                         val
-                       end
-                      # TODO if val is a hash / array => look for nested class & cast
+            unless val.nil?
+              case field_type
+              when 'string'
+                conv_val = process_string_type(field_props['format'], val)
+              when 'integer'
+                conv_val = val.to_i
+              when 'object'
+                conv_val = process_object_type(key, val)
+              when 'array'
+                conv_val = process_array_type(key, val)
+              else
+                conv_val = val
+              end
+            end
+
             obj.schema_attrs["#{key}"] = conv_val
           end
           obj
@@ -127,6 +119,34 @@ module SchemaTools
         end
 
         private
+
+        def process_string_type(field_format, value)
+          if field_format == 'date'
+            Date.parse(value) # or be explicit? Date.strptime('2001-02-03', '%Y-%m-%d')
+          elsif field_format == 'date-time'
+            Time.parse(value) # vs Time.strptime
+          else
+           value.to_s
+          end
+        end
+
+        def process_object_type(field_name, value)
+          if nested_class(field_name)
+            nested_class(field_name).from_hash(value)
+          else
+            value
+          end
+        end
+
+        def process_array_type(field_name, value)
+          if nested_class(field_name.to_s.singularize)
+            value.map do |element|
+              nested_class(field_name.to_s.singularize).from_hash(element)
+            end
+          else
+            value
+          end
+        end
 
         def nested_class(field_name)
           klass = "#{base_class}::#{field_name.to_s.camelize}"

--- a/lib/schema_tools/modules/attributes.rb
+++ b/lib/schema_tools/modules/attributes.rb
@@ -76,8 +76,7 @@ module SchemaTools
         # @param [Hash{String=>Mixed}] json string or hash
         # @param [Object] obj if you want to update an existing objects
         # attributes. e.g during an update
-        # @param [Hash] flags for switching between ways to slurp in hash
-        def from_hash(hash, obj=nil, opts={})
+        def from_hash(hash, obj=nil)
           # test if hash is nested and shift up
           if hash.length == 1 && hash["#{schema_name}"]
             hash = hash["#{schema_name}"]

--- a/spec/fixtures/schemata/item.json
+++ b/spec/fixtures/schemata/item.json
@@ -1,0 +1,6 @@
+{
+  "type" : "object",
+  "properties" : {
+    "id" : { "type" : "string" }
+  }
+}

--- a/spec/fixtures/schemata/item_collection.json
+++ b/spec/fixtures/schemata/item_collection.json
@@ -1,0 +1,11 @@
+{
+  "type" : "object",
+  "properties" : {
+    "items" : {
+      "type" : "array",
+      "properties" : {
+        "$ref" : "item.json#properties"
+      }
+    }
+  }
+}

--- a/spec/schema_tools/modules/attributes_spec.rb
+++ b/spec/schema_tools/modules/attributes_spec.rb
@@ -15,6 +15,21 @@ class Numbers
   has_schema_attrs :numbers, :schema => schema_as_ruby_object
 end
 
+class WorkAddress
+  include SchemaTools::Modules::Attributes
+  has_schema_attrs :address
+end
+
+class ItemCollection
+  include SchemaTools::Modules::Attributes
+  has_schema_attrs :item_collection
+end
+
+class Item
+  include SchemaTools::Modules::Attributes
+  has_schema_attrs :item
+end
+
 describe SchemaTools::Modules::Attributes do
 
   context 'included' do
@@ -118,6 +133,18 @@ describe SchemaTools::Modules::Attributes do
       obj = TestClient.from_hash(hash)
       expect(obj.created_at.zone).to eq 'UTC'
       expect(obj.created_at.hour).to eq 10
+    end
+
+    it 'makes nested objects if there are nested hashes' do
+      hash = {work_address: {}}
+      obj = TestClient.from_hash(hash)
+      expect(obj.work_address).to be_an_instance_of(WorkAddress)
+    end
+
+    it 'makes nested array of objects if there are nested arrays of hashes' do
+      hash = {items: [{}, {}]}
+      obj = ItemCollection.from_hash(hash)
+      expect(obj.items.first).to be_an_instance_of(Item)
     end
 
     it 'updates an object' do


### PR DESCRIPTION
This PR parses nested objects and collections and dumps them into user-defined objects for them. If the user has not defined a custom class for the nested element, then the hash or array is preserved. This behavior is called when calling `from_hash` or when calling `from_json`